### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/*
 work/*
+.idea

--- a/src/main/resources/hudson/plugins/tics/TicsPublisherBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/tics/TicsPublisherBuildAction/index.jelly
@@ -3,7 +3,7 @@
   <l:layout>
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.gif" href=".." title="${%Back to Build}" />
+        <l:task icon="icon-up icon-md" href=".." title="${%Back to Build}" />
       </l:tasks>
     </l:side-panel>
 


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
In case of your plugin, I've removed the header icons, because that is what modern Jenkins does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @danai-andriopoulou 
Thanks in advance!