### PR TITLE
Update TicsAnalyzer.java

### DIFF
--- a/src/main/java/hudson/plugins/tics/TicsAnalyzer.java
+++ b/src/main/java/hudson/plugins/tics/TicsAnalyzer.java
@@ -209,7 +209,7 @@ public class TicsAnalyzer extends Builder implements SimpleBuildStep {
         if (isLinux) {
             return ". <(curl --silent --show-error \'" + url + "\' )";
         } else {
-            return "powershell \"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('" + url + "'))\"";
+            return "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('" + url + "'))";
         }
     }
 


### PR DESCRIPTION
31202: [Jenkins Plugin] Changed bootstrap invocation such the environment persists.
[https://redmine.tiobe.com/issues/31202](url)

Made sure environment variables are available during CMD invocation. Therefore I removed the first
powershell as this script is already running in a powershell.

**Before:**
```
powershell(
  powershell(
      bootstrap) <-- Environment variables stay inside
  cmd(tics analysis)    <-- Cannot find TICSQServer
)
```

**After:**
```
powershell(
  bootstrap             <-- Sets all required variables
  cmd(tics analysis)    <-- Inherits environment from parent
)
```