### PR TITLE
#30349: Fixed duplicate label on job overview page

### DIFF
--- a/src/main/java/hudson/plugins/tics/AbstractTicsPublisherAction.java
+++ b/src/main/java/hudson/plugins/tics/AbstractTicsPublisherAction.java
@@ -3,17 +3,19 @@ package hudson.plugins.tics;
 import hudson.model.Action;
 
 public abstract class AbstractTicsPublisherAction implements Action {
+    @Override
     public String getDisplayName() {
         return "TICS Results";
     }
-    
+
+    @Override
     public String getUrlName() {
         return "tics";
     }
-    
+
     public boolean isFloatingBoxActive() {
         return true;
     }
-    
-    
+
+
 }

--- a/src/main/java/hudson/plugins/tics/AuthHelper.java
+++ b/src/main/java/hudson/plugins/tics/AuthHelper.java
@@ -37,8 +37,8 @@ import hudson.util.Secret;
 import jenkins.model.Jenkins;
 
 public final class AuthHelper {
-    private AuthHelper() {};
-    
+    private AuthHelper() {}
+
     public static final String TICSAUTHTOKEN = "TICSAUTHTOKEN";
 
     /**
@@ -71,13 +71,13 @@ public final class AuthHelper {
     }
 
     /**
-     * Looks for the TICSAUTHTOKEN in the Credentials plugin for given credentialsId, or the or the provided {@link EnvVars} 
+     * Looks for the TICSAUTHTOKEN in the Credentials plugin for given credentialsId, or the or the provided {@link EnvVars}
      * and returns its value.
-     * <b>Warning</b> If the provided variables contains  
+     * <b>Warning</b> If the provided variables contains
      **/
     public static Optional<String> lookupTicsAuthToken(final Job<?, ?> job, final String credentialsId, final EnvVars buildEnv) {
         final String errorMessage = "The provided credentials are of the wrong type. Only two types are supported; username & password and secret text.";
-        // TICSAUTHTOKEN can be set through the credentials dropdown available within our plugin 
+        // TICSAUTHTOKEN can be set through the credentials dropdown available within our plugin
         // In this case, the credentialsId is present
         if (!Strings.isNullOrEmpty(credentialsId)) {
             return AuthHelper.lookupCredentials(StringCredentials.class, job, credentialsId)
@@ -88,7 +88,7 @@ public final class AuthHelper {
             // In both cases, an environment variable is created.
             // If TICSAUTHTOKEN is set as a credentials parameter then the saved format of the environment variable is TICSAUTHTOKEN=credentialsId
             // For all the other cases, the environment variable is of the format TICSAUTHTOKEN=value
-            String ticsTokenEnv = buildEnv.get(TICSAUTHTOKEN);
+            final String ticsTokenEnv = buildEnv.get(TICSAUTHTOKEN);
             if (!Strings.isNullOrEmpty(ticsTokenEnv)) {
                 return AuthHelper.lookupCredentials(StringCredentials.class, job, ticsTokenEnv)
                         .map(c -> Optional.of(c.getSecret().getPlainText()))
@@ -109,7 +109,7 @@ public final class AuthHelper {
             }
             final Pair<String, String> splittedPair = Pair.of(splitted[0], splitted[1]);
             return splittedPair;
-        } catch (Exception ex) { 
+        } catch (final Exception ex) {
           throw new IllegalArgumentException("Malformed authentication token. Please make sure you are using a valid token from the TICS Viewer.", ex);
         }
     }

--- a/src/main/java/hudson/plugins/tics/MeasureApiSuccessResponse.java
+++ b/src/main/java/hudson/plugins/tics/MeasureApiSuccessResponse.java
@@ -40,6 +40,7 @@ public class MeasureApiSuccessResponse<T> {
 
         public TqiVersion() { /* for gson */ }
 
+        @Override
         public int compareTo(final TqiVersion that) {
             return ComparisonChain.start()
                 .compare(this.major, that.major)
@@ -56,16 +57,20 @@ public class MeasureApiSuccessResponse<T> {
             return result;
         }
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
+        public boolean equals(final Object obj) {
+            if (this == obj) {
                 return true;
-            if (obj == null)
+            }
+            if (obj == null) {
                 return false;
-            if (getClass() != obj.getClass())
+            }
+            if (getClass() != obj.getClass()) {
                 return false;
-            TqiVersion other = (TqiVersion) obj;
-            if (this.major != other.major)
+            }
+            final TqiVersion other = (TqiVersion) obj;
+            if (this.major != other.major) {
                 return false;
+            }
             return this.minor == other.minor;
         }
     }

--- a/src/main/java/hudson/plugins/tics/TicsPipelinePublish.java
+++ b/src/main/java/hudson/plugins/tics/TicsPipelinePublish.java
@@ -14,6 +14,8 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.google.common.base.Strings;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -47,7 +49,7 @@ public class TicsPipelinePublish extends Recorder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull final Run<?, ?> run, @Nonnull final FilePath workspace, @Nonnull final Launcher launcher, @Nonnull final TaskListener listener) throws InterruptedException, IOException {
+    public void perform(@Nonnull final Run<?, ?> run, @Nonnull final FilePath workspace, @NonNull final EnvVars envvars, @Nonnull final Launcher launcher, @Nonnull final TaskListener listener) throws InterruptedException, IOException {
         if (Strings.isNullOrEmpty(viewerUrl)) {
             throw new IllegalArgumentException("The pipeline method '" + PUBLISH_TICS_RESULTS + "' was used without specifying the 'viewerUrl'. " +
                     "For instance a 'viewerUrl' looks like: 'http://www.company.com:42506/tiobeweb/TICS'.\n");
@@ -58,9 +60,9 @@ public class TicsPipelinePublish extends Recorder implements SimpleBuildStep {
             }
         }
 
-        final String credentialsId = getCredentials();
-        final TicsPublisher tp = new TicsPublisher(viewerUrl, getTicsProjectPath(), credentialsId, this.checkQualityGate, this.failIfQualityGateFails);
-        tp.perform(run, workspace, launcher, listener);
+        final String creds = getCredentials();
+        final TicsPublisher tp = new TicsPublisher(viewerUrl, getTicsProjectPath(), creds, this.checkQualityGate, this.failIfQualityGateFails);
+        tp.perform(run, workspace, envvars, launcher, listener);
     }
 
     private String getTicsProjectPath() {
@@ -139,7 +141,7 @@ public class TicsPipelinePublish extends Recorder implements SimpleBuildStep {
     public void setFailIfQualityGateFails(final boolean value) {
         this.failIfQualityGateFails = value;
     }
-    
+
     @DataBoundSetter
     public void setCredentialsId(final String value) {
         this.credentialsId = value;

--- a/src/main/java/hudson/plugins/tics/TicsPipelineRun.java
+++ b/src/main/java/hudson/plugins/tics/TicsPipelineRun.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -73,7 +74,7 @@ public class TicsPipelineRun extends Builder implements SimpleBuildStep {
     public LinkedHashMap<String, String> environmentVariables;
     public boolean installTics;
     public String credentialsId;
-    
+
 
     @DataBoundConstructor
     public TicsPipelineRun(
@@ -84,8 +85,9 @@ public class TicsPipelineRun extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull final Run run,
+    public void perform(@Nonnull final Run<?, ?> run,
                         @Nonnull final FilePath workspace,
+                        @Nonnull final EnvVars envvars,
                         @Nonnull final Launcher launcher,
                         @Nonnull final TaskListener listener) throws IOException, InterruptedException {
 
@@ -105,7 +107,7 @@ public class TicsPipelineRun extends Builder implements SimpleBuildStep {
                 installTics,
                 credentialsId
         );
-        ta.perform(run, workspace, launcher, listener);
+        ta.perform(run, workspace, envvars, launcher, listener);
     }
 
     private String convertEnvironmentVariablesToString() {
@@ -196,12 +198,12 @@ public class TicsPipelineRun extends Builder implements SimpleBuildStep {
     public void setEnvironmentVariables(final LinkedHashMap<String, String> value) {
         this.environmentVariables = value;
     }
-    
+
     @DataBoundSetter
     public void setInstallTics(final boolean value) {
         this.installTics = value;
     }
-    
+
     @DataBoundSetter
     public void setCredentialsId(final String value) {
         this.credentialsId = value;

--- a/src/main/java/hudson/plugins/tics/TicsPublisher.java
+++ b/src/main/java/hudson/plugins/tics/TicsPublisher.java
@@ -18,6 +18,8 @@ import org.kohsuke.stapler.verb.POST;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -97,7 +99,7 @@ public class TicsPublisher extends Recorder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull final Run<?, ?> run, @Nonnull final FilePath workspace, @Nonnull final Launcher launcher, @Nonnull final TaskListener listener) throws IOException, RuntimeException, InterruptedException {
+    public void perform(@Nonnull final Run<?, ?> run, @Nonnull final FilePath workspace, @NonNull final EnvVars envvars, @Nonnull final Launcher launcher, @Nonnull final TaskListener listener) throws IOException, RuntimeException, InterruptedException {
         final Optional<Pair<String, String>> usernameAndPassword = AuthHelper.lookupUsernameAndPasswordFromCredentialsId(run.getParent(), credentialsId, run.getEnvironment(listener));
         final String ticsPath1 = Util.replaceMacro(Preconditions.checkNotNull(Strings.emptyToNull(this.ticsPath), "Path not specified"), run.getEnvironment(listener));
 
@@ -128,7 +130,7 @@ public class TicsPublisher extends Recorder implements SimpleBuildStep {
             gateData = null;
         }
 
-        run.addAction(new TicsPublisherBuildAction(run, tqiData, gateData, tiobeWebBaseUrl));
+        run.addAction(new TicsPublisherBuildAction(run, ticsPath1, tqiData, gateData, tiobeWebBaseUrl));
         run.setResult(Result.SUCCESS); // note that: "has no effect when the result is already set and worse than the proposed result"
     }
 

--- a/src/main/java/hudson/plugins/tics/TicsPublisherBuildAction.java
+++ b/src/main/java/hudson/plugins/tics/TicsPublisherBuildAction.java
@@ -36,21 +36,24 @@ public class TicsPublisherBuildAction extends AbstractTicsPublisherAction implem
     private final Run<?, ?> run;
     public final MetricData tqiData;
     public final QualityGateData gateData;
+    public final String ticsPath;
     private final String tiobeWebBaseUrl;
 
     private final List<TicsPublisherProjectAction> projectActions;
 
     public TicsPublisherBuildAction(
             final Run<?, ?> run,
+            final String ticsPath,
             final MetricData tqiData,
             final QualityGateData QualityGateData,
             final String tiobeWebBaseUrl
     ) {
         this.run = run;
+        this.ticsPath = ticsPath;
         this.tqiData = tqiData;
         this.gateData = QualityGateData;
         final List<TicsPublisherProjectAction> actions = new ArrayList<>();
-        actions.add(new TicsPublisherProjectAction(run));
+        actions.add(new TicsPublisherProjectAction(run, ticsPath));
         this.projectActions = actions;
         this.tiobeWebBaseUrl = tiobeWebBaseUrl;
     }

--- a/src/main/java/hudson/plugins/tics/TicsPublisherProjectAction.java
+++ b/src/main/java/hudson/plugins/tics/TicsPublisherProjectAction.java
@@ -1,14 +1,20 @@
 package hudson.plugins.tics;
 
+import java.util.List;
+import java.util.Objects;
+
 import hudson.model.Run;
 
 public class TicsPublisherProjectAction extends AbstractTicsPublisherAction {
     public final Run<?, ?> run;
+    public final String ticsPath;
 
-    public TicsPublisherProjectAction(final Run<?, ?> run) {
+    public TicsPublisherProjectAction(final Run<?, ?> run, final String ticsPath) {
         this.run = run;
+        this.ticsPath = ticsPath;
     }
 
+    @Override
     public String getIconFileName() {
         // We return null to indicate that their should not be a link in the sidebar on the left.
         // The TICS results are already in the floating box.
@@ -22,9 +28,16 @@ public class TicsPublisherProjectAction extends AbstractTicsPublisherAction {
      */
     public TicsPublisherBuildAction getLastBuild() {
         for (Run<?, ?> b = run.getParent().getLastBuild(); b != null; b = b.getPreviousBuild()) {
-            final TicsPublisherBuildAction r = b.getAction(TicsPublisherBuildAction.class);
-            if (r != null) {
-                return r;
+            final List<TicsPublisherBuildAction> actions = b.getActions(TicsPublisherBuildAction.class);
+            for (final TicsPublisherBuildAction action : actions) {
+                if (action == null) {
+                    continue;
+                }
+                if (Objects.equals(ticsPath, action.ticsPath) // #30349: differentiate between multiple publish steps within a single pipeline invocation
+                        || this.ticsPath == null // happens for builds at the time that TicsPublisherProjectAction did not yet store ticsPath
+                        ) {
+                    return action;
+                }
             }
         }
         return null;

--- a/src/main/java/hudson/plugins/tics/TqiPublisherResultBuilder.java
+++ b/src/main/java/hudson/plugins/tics/TqiPublisherResultBuilder.java
@@ -136,7 +136,7 @@ public class TqiPublisherResultBuilder {
         }
         final MetricValue<List<Run>> mv = resp.data.get(0);
         return Lists.reverse(Optional.ofNullable(mv.value).orElseGet(ArrayList::new));
-    };
+    }
 
     private final Supplier<Optional<Baseline>> baseline = Suppliers.memoize(new Supplier<Optional<Baseline>>() {
         @Override


### PR DESCRIPTION
Fixed issue where Jenkins job overview page would show duplicate Quality Indicator labels when there are multiple 'publishTicsResults' steps in single pipeline.

Also:
* Fixed some deprecation warnings produced by maven-compiler-plugin.

See https://redmine.tiobe.com/issues/30349

Note that the main change of this PR is src/main/java/hudson/plugins/tics/TicsPublisherProjectAction.java. Other changes are for fixing deprecation and Eclipse compiler warnings.
