### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>tics</artifactId>
     <packaging>hpi</packaging>
-    <version>2022.4.0.3</version>
+    <version>2022.4.0.3-SNAPSHOT</version>
     <properties>
         <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>


### PR DESCRIPTION
The plugin version number needs to include suffix -SNAPSHOT before it is being released. This is needed for releasing the plugin to the Jenkins marketplace. Otherwise we will encounter this error message:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project tics: You don't have a SNAPSHOT project in the reactor projects list. -> [Help 1]

Reference: https://stackoverflow.com/a/20056439

