### PR TITLE
Fixing TICSQServer call issue in #33818 and setup unit tests for TiCS Jenkins Plugin (#33819)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,28 @@
             <artifactId>jsoup</artifactId>
             <version>1.13.1</version>
         </dependency>
+        <!-- 
+        <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-basic-steps</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-cps</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-durable-task-step</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-job</artifactId>
+          <scope>test</scope>
+        </dependency>
+        -->
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -132,28 +132,6 @@
             <artifactId>jsoup</artifactId>
             <version>1.13.1</version>
         </dependency>
-        <!-- 
-        <dependency>
-          <groupId>org.jenkins-ci.plugins.workflow</groupId>
-          <artifactId>workflow-basic-steps</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins.workflow</groupId>
-          <artifactId>workflow-cps</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins.workflow</groupId>
-          <artifactId>workflow-durable-task-step</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins.workflow</groupId>
-          <artifactId>workflow-job</artifactId>
-          <scope>test</scope>
-        </dependency>
-        -->
     </dependencies>
 
     <build>

--- a/src/main/java/hudson/plugins/tics/AbstractApiCall.java
+++ b/src/main/java/hudson/plugins/tics/AbstractApiCall.java
@@ -71,9 +71,6 @@ public abstract class AbstractApiCall {
                 final String proxyName = proxy.getName();
                 final int proxyPort = proxy.getPort();
                 final List<Pattern> noProxyPatterns = proxy.getNoProxyHostPatterns();
-                // Bypassing proxy for internal hosts by default
-                noProxyPatterns.add(Pattern.compile("localhost"));
-                noProxyPatterns.add(Pattern.compile("127\\..*"));
                 final String proxyUser = proxy.getUserName();
                 final String proxyPass = Secret.toString(proxy.getSecretPassword());
 
@@ -101,6 +98,9 @@ public abstract class AbstractApiCall {
 
     protected boolean isProxyExempted(final String urlStr, final List<Pattern> noProxyPatterns) {
         Matcher matcher;
+        // Bypassing proxy for internal hosts by default
+        noProxyPatterns.add(Pattern.compile("localhost"));
+        noProxyPatterns.add(Pattern.compile("127\\..*"));
         for (final Pattern p : noProxyPatterns) {
             matcher = p.matcher(urlStr);
             if(matcher.find()) {

--- a/src/main/java/hudson/plugins/tics/AbstractApiCall.java
+++ b/src/main/java/hudson/plugins/tics/AbstractApiCall.java
@@ -4,7 +4,6 @@ import java.io.PrintStream;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -73,7 +72,6 @@ public abstract class AbstractApiCall {
             if (proxy != null) {
                 final String proxyName = proxy.getName();
                 final int proxyPort = proxy.getPort();
-//                final List<Pattern> noProxyPatterns = proxy.getNoProxyHostPatterns();
                 final ImmutableList<Pattern> noProxyPatterns = ImmutableList.copyOf(proxy.getNoProxyHostPatterns());
                 final String proxyUser = proxy.getUserName();
                 final String proxyPass = Secret.toString(proxy.getSecretPassword());
@@ -100,7 +98,7 @@ public abstract class AbstractApiCall {
     }
 
 
-    protected boolean isProxyExempted(final String urlStr, final List<Pattern> noProxyPatterns) {
+    protected boolean isProxyExempted(final String urlStr, final ImmutableList<Pattern> noProxyPatterns) {
         Matcher matcher;
         // Bypassing proxy for internal addresses by default
         for (final Pattern p : Iterables.concat(noProxyPatterns, LOCALHOST_PATTERNS)) {

--- a/src/main/java/hudson/plugins/tics/TicsAnalyzer.java
+++ b/src/main/java/hudson/plugins/tics/TicsAnalyzer.java
@@ -233,9 +233,7 @@ public class TicsAnalyzer extends Builder implements SimpleBuildStep {
 
         final String scriptSuffix =  isLinux ? ".sh" : ".ps1";
         final String scriptContentStart = isLinux ? "#!/bin/bash" : "";
-        final String ticsAnalysisCmdEscaped = isLinux
-                ? ticsAnalysisCmd.toList().stream().map(a -> StringEscapeUtils.escapeXSI(a)).collect(Collectors.joining(" "))
-                : getTicsAnalysisCmdEscapedWin(ticsAnalysisCmd);
+        final String ticsAnalysisCmdEscaped = getTicsAnalysisCmdEscaped(ticsAnalysisCmd, isLinux);
 
         final FilePath createTempFile = workspace.createTempFile("tics", scriptSuffix);
 
@@ -248,7 +246,17 @@ public class TicsAnalyzer extends Builder implements SimpleBuildStep {
         return createTempFile;
     }
 
-    protected String getTicsAnalysisCmdEscapedWin(final ArgumentListBuilder ticsAnalysisCmd) {
+    protected String getTicsAnalysisCmdEscaped(final ArgumentListBuilder ticsAnalysisCmd, final boolean isLinux) {
+        return isLinux
+                ? getTicsAnalysisCmdEscapedLinux(ticsAnalysisCmd)
+                : getTicsAnalysisCmdEscapedWin(ticsAnalysisCmd);
+    }
+
+    private String getTicsAnalysisCmdEscapedLinux(final ArgumentListBuilder ticsAnalysisCmd) {
+        return ticsAnalysisCmd.toList().stream().map(a -> StringEscapeUtils.escapeXSI(a)).collect(Collectors.joining(" "));
+    }
+
+    private String getTicsAnalysisCmdEscapedWin(final ArgumentListBuilder ticsAnalysisCmd) {
         return removeDoubleQuoteFromCommand("calc", ticsAnalysisCmd.toWindowsCommand().toString());
     }
 

--- a/src/main/java/hudson/plugins/tics/TicsAnalyzer.java
+++ b/src/main/java/hudson/plugins/tics/TicsAnalyzer.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -234,15 +235,30 @@ public class TicsAnalyzer extends Builder implements SimpleBuildStep {
                 ? ticsAnalysisCmd.toList().stream().map(a -> StringEscapeUtils.escapeXSI(a)).collect(Collectors.joining(" "))
                 : ticsAnalysisCmd.toWindowsCommand().toString();
 
+        // trim double quotes for metric arguments after the -calc flag,e.g. -calc "CODINGSTANDARD",
+        // that were added for Windows commands
+        final String ticsAnalysisCmdCleaned = cleanTicsAnalysisCmd(ticsAnalysisCmdEscaped);
         final FilePath createTempFile = workspace.createTempFile("tics", scriptSuffix);
-
         final String contents = scriptContentStart + "\n"
                 + bootstrapCmd + "\n"
-                + ticsAnalysisCmdEscaped;
+                + ticsAnalysisCmdCleaned;
 
         createTempFile.write(contents, "UTF-8");
 
         return createTempFile;
+    }
+
+    private String cleanTicsAnalysisCmd(final String escapedCmd) {
+        final Pattern pattern = Pattern.compile("calc \"\\S+\"");
+        final Matcher matcher = pattern.matcher(escapedCmd);
+        String cleanCmd = escapedCmd;
+
+        while (matcher.find()) {
+            final String group = matcher.group().replaceAll("\"", "");
+            cleanCmd = cleanCmd.replaceFirst("calc \"\\S+\"", group);
+        }
+
+        return cleanCmd;
     }
 
     private String getInstallTicsApiUrl(final String tiobewebBaseUrl, final String os) throws URISyntaxException {

--- a/src/test/java/hudson/plugins/tics/AbstractApiCallTest.java
+++ b/src/test/java/hudson/plugins/tics/AbstractApiCallTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -25,11 +26,7 @@ public class AbstractApiCallTest {
     }
 
     private List<Pattern> getPatterns(final List<String> regexes) {
-        final List<Pattern> noProxyPatterns = new ArrayList<>();
-        for (final String pattern: regexes) {
-            noProxyPatterns.add(Pattern.compile(pattern));
-        }
-        return noProxyPatterns;
+        return regexes.stream().map(Pattern::compile).collect(Collectors.toList());
     }
 
     private List<NoProxyTestCase> getNoProxyTestCases() {

--- a/src/test/java/hudson/plugins/tics/AbstractApiCallTest.java
+++ b/src/test/java/hudson/plugins/tics/AbstractApiCallTest.java
@@ -1,0 +1,91 @@
+package hudson.plugins.tics;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+public class AbstractApiCallTest {
+
+    private class NoProxyTestCase {
+        public List<Pattern> noProxyPatterns;
+        public String targetUrl;
+        public boolean expectedResult;
+
+        public NoProxyTestCase(final List<Pattern> noProxyPatterns, final String targetUrl, final boolean expectedResult) {
+            this.noProxyPatterns = noProxyPatterns;
+            this.targetUrl = targetUrl;
+            this.expectedResult = expectedResult;
+        }
+    }
+
+    private List<Pattern> getPatterns(final List<String> regexes) {
+        final List<Pattern> noProxyPatterns = new ArrayList<>();
+        for (final String pattern: regexes) {
+            noProxyPatterns.add(Pattern.compile(pattern));
+        }
+        return noProxyPatterns;
+    }
+
+    private List<NoProxyTestCase> getNoProxyTestCases() {
+        final List<NoProxyTestCase> testCases = new ArrayList<>();
+
+        // Test cases where target url is using an IP address
+        // no-proxy is not set
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList()), "http://192.168.1.204:42506/tiobeweb/TICS", false));
+        // all urls are exempted
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList(".*")), "http://192.168.1.204:42506/tiobeweb/TICS", true));
+        // no-proxy pattern matches
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("192\\.168\\.1\\.204")), "http://192.168.1.204:42506/tiobeweb/TICS", true));
+        // no-proxy pattern matches
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("192\\..*")), "http://192.168.1.204:42506/tiobeweb/TICS", true));
+        // no-proxy pattern does not match
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("\\.tiobe\\.com")), "http://192.168.1.204:42506/tiobeweb/TICS", false));
+
+
+        //Test cases where target url is using a domain name
+        // no-proxy is not set
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList()), "https://testlab.tiobe.com/tiobeweb/testlab", false));
+        // all urls are exempted
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList(".*")), "https://testlab.tiobe.com/tiobeweb/testlab", true));
+        // no-proxy pattern matches
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("testlab\\.tiobe\\.com")), "https://testlab.tiobe.com/tiobeweb/testlab", true));
+        // no-proxy pattern matches
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList(".*\\.tiobe\\.com")), "https://testlab.tiobe.com/tiobeweb/testlab", true));
+        // no-proxy pattern matches
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("\\.tiobe\\.com")), "https://testlab.tiobe.com/tiobeweb/testlab", true));
+        // no-proxy pattern matches
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("testlab\\.tiobe\\.com", ".*\\.tiobe\\.com", "\\.tiobe\\.com")), "https://testlab.tiobe.com/tiobeweb/testlab", true));
+        // no-proxy pattern does not match
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("192\\..*")), "https://testlab.tiobe.com/tiobeweb/testlab", false));
+
+        // Test cases where target url is an internal address (localhost or 127.*). The internal addresses are exempted from proxy by default.
+        // no-proxy is not set
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList()), "https://localhost:42506/tiobeweb/testlab", true));
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList()), "https://127.0.0.1:42506/tiobeweb/testlab", true));
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList()), "https://127.1.2.1:42506/tiobeweb/testlab", true));
+        // all urls are exempted
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList(".*")), "https://localhost:42506/tiobeweb/testlab", true));
+        // no-proxy pattern matches
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("localhost", "127.0.0.1")), "https://localhost:42506/tiobeweb/testlab", true));
+        // no-proxy pattern does not match
+        testCases.add(new NoProxyTestCase(getPatterns(Arrays.asList("testlab\\.tiobe\\.com")), "https://localhost:42506/tiobeweb/testlab", true));
+
+        return testCases;
+    }
+
+    @Test
+    public void testIsProxyExempted() {
+        final MeasureApiCall apiCall = new MeasureApiCall(null, "http://192.168.1.204:42506/tiobeweb/TICS/api/public/v1/Measure", Optional.empty());
+        for (final NoProxyTestCase testCase : getNoProxyTestCases()) {
+            final boolean isProxyExempted = apiCall.isProxyExempted(testCase.targetUrl, testCase.noProxyPatterns);
+            assertEquals(testCase.expectedResult, isProxyExempted);
+        }
+    }
+
+}

--- a/src/test/java/hudson/plugins/tics/AbstractApiCallTest.java
+++ b/src/test/java/hudson/plugins/tics/AbstractApiCallTest.java
@@ -11,15 +11,17 @@ import java.util.stream.Collectors;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
+
 public class AbstractApiCallTest {
 
     private class NoProxyTestCase {
-        public List<Pattern> noProxyPatterns;
+        public ImmutableList<Pattern> noProxyPatterns;
         public String targetUrl;
         public boolean expectedResult;
 
         public NoProxyTestCase(final List<Pattern> noProxyPatterns, final String targetUrl, final boolean expectedResult) {
-            this.noProxyPatterns = noProxyPatterns;
+            this.noProxyPatterns = ImmutableList.copyOf(noProxyPatterns);
             this.targetUrl = targetUrl;
             this.expectedResult = expectedResult;
         }

--- a/src/test/java/hudson/plugins/tics/TicsAnalyzerTest.java
+++ b/src/test/java/hudson/plugins/tics/TicsAnalyzerTest.java
@@ -1,0 +1,103 @@
+package hudson.plugins.tics;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import hudson.EnvVars;
+import hudson.util.ArgumentListBuilder;
+
+public class TicsAnalyzerTest {
+
+    public final Metrics calcMetrics = getMetrics(true, false, false, true);
+
+    public final Metrics recalcMetrics = getMetrics(false, true, true, false);
+
+    public final String ticsPath = "";
+    public final String ticsConfiguration = "http://192.168.1.204:42506/tiobeweb/TICS/api/cfg?name=default";
+    public final String projectName = "cpp-game-vs";
+    public final String branchName = "master";
+    public final String branchDirectory = "D:\\Development\\dev_test\\projects\\cpp-game-vs" ;
+    public final String environmentVariables = "";
+    public final boolean createTmpdir = true;
+    public final String tmpdir = "D:\\Development\\dev_test\\tmp\\33733-tmpdir" ;
+    public final String extraArguments = "";
+    public final boolean installTics = false;
+    public final String credentialsId = "token-leila-machine";
+    private final TicsAnalyzer ta = new TicsAnalyzer(ticsPath
+            , ticsConfiguration
+            , projectName
+            , branchName
+            , branchDirectory
+            , environmentVariables
+            , createTmpdir
+            , tmpdir
+            , extraArguments
+            , calcMetrics
+            , recalcMetrics
+            , installTics
+            , credentialsId);
+
+
+    private Metrics getMetrics(final boolean codingStandards, final boolean compilerWarnings, final boolean finalize, final boolean loc) {
+        return new Metrics(
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                codingStandards,
+                compilerWarnings,
+                false,
+                false,
+                false,
+                false,
+                finalize,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                loc,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+        );
+    }
+
+
+    @Test
+    public void testGetTicsAnalysisCmdEscapedWin() {
+        final EnvVars buildEnv = new EnvVars();
+        final boolean isLauncherUnix = false;
+        final ArgumentListBuilder ticsAnalysisCmd = ta.getTicsQServerArgs(buildEnv, isLauncherUnix);
+        final String ticsAnalysisCmdEscapedWin = ta.getTicsAnalysisCmdEscapedWin(ticsAnalysisCmd);
+        final String ticsAnalysisCmdExpected = "cmd.exe /C \"TICSQServer.exe -project cpp-game-vs -branchname master -branchdir D:\\Development\\dev_test\\projects\\cpp-game-vs -tmpdir D:\\Development\\dev_test\\tmp\\33733-tmpdir -calc CODINGSTANDARD,LOC -recalc COMPILERWARNING,FINALIZE && exit %%ERRORLEVEL%%\"";
+        assertEquals(ticsAnalysisCmdExpected, ticsAnalysisCmdEscapedWin);
+    }
+
+    @Test
+    public void testRemoveDoubleQuoteFromCommand() {
+        String ticsAnalysisCmd;
+        String ticsAnalysisCmdExpected;
+
+        ticsAnalysisCmd = "cmd.exe /C \"TICSQServer.exe -project game-gcc -branchname master -branchdir D:\\Development\\dev_test\\workspace\\tics-test-33733-UI -tmpdir D:\\Development\\dev_test\\tmp\\33733-tmpdir -calc \"CODINGSTANDARD,LOC\" && exit %%ERRORLEVEL%%\"";
+        ticsAnalysisCmdExpected = "cmd.exe /C \"TICSQServer.exe -project game-gcc -branchname master -branchdir D:\\Development\\dev_test\\workspace\\tics-test-33733-UI -tmpdir D:\\Development\\dev_test\\tmp\\33733-tmpdir -calc CODINGSTANDARD,LOC && exit %%ERRORLEVEL%%\"";
+        assertEquals(ticsAnalysisCmdExpected, ta.removeDoubleQuoteFromCommand("calc", ticsAnalysisCmd));
+
+        ticsAnalysisCmd = "cmd.exe /C \"TICSQServer.exe -project cpp-game-vs -branchname master -branchdir D:\\Development\\dev_test\\projects\\cpp-game-vs -tmpdir D:\\Development\\dev_test\\tmp\\33733-tmpdir -calc \"CODINGSTANDARD,LOC\" -recalc \"COMPILERWARNING,FINALIZE\" && exit %%ERRORLEVEL%%\"";
+        ticsAnalysisCmdExpected = "cmd.exe /C \"TICSQServer.exe -project cpp-game-vs -branchname master -branchdir D:\\Development\\dev_test\\projects\\cpp-game-vs -tmpdir D:\\Development\\dev_test\\tmp\\33733-tmpdir -calc CODINGSTANDARD,LOC -recalc COMPILERWARNING,FINALIZE && exit %%ERRORLEVEL%%\"";
+        assertEquals(ticsAnalysisCmdExpected, ta.removeDoubleQuoteFromCommand("calc", ticsAnalysisCmd));
+    }
+}


### PR DESCRIPTION
Implementation for fixing TICSQServer analysis invocation on a Windows agent due to faulty double quotes around -calc and -recalc values.

Add unit tests for generation of TICSQserver analysis command both for Windows and Linux

Add unit test for checking proxy exemption.